### PR TITLE
Export custom ClusterRoles and SecurityContextConstraints

### DIFF
--- a/replica-builder/install-builder/pkg/installer/utils.go
+++ b/replica-builder/install-builder/pkg/installer/utils.go
@@ -75,3 +75,7 @@ func AppendToFile(file string, text string, args ...any) {
 		fmt.Fprint(f, text)
 	}
 }
+
+func SystemNameForSA(namespace string, serviceAccount string) string {
+	return fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceAccount)
+}


### PR DESCRIPTION
Loading SCCs and matching the SA name against the SCC.users
In case a match is found, the SCC is re-created to use the current SA as the single user, and a replacements section is created in the kustomize template to update the SA system name with the actual package name